### PR TITLE
fix: remove initial values from data dialog

### DIFF
--- a/src/pages/tables/edit-table-template/EditTableCell/DataSelectorDialog/DataSelectorDialog.js
+++ b/src/pages/tables/edit-table-template/EditTableCell/DataSelectorDialog/DataSelectorDialog.js
@@ -49,7 +49,7 @@ export class DataSelectorDialog extends Component {
             ? defaultGroupId(this.props.initialValues.dataType)
             : ALL_ID,
         groupDetail: this.props.initialValues.groupDetail || '',
-        filterText: this.props.initialValues.item?.name || '',
+        filterText: '',
         items: [],
         nextPage: null,
         filter: {},

--- a/src/pages/tables/edit-table-template/EditTableCell/DataSelectorDialog/DataSelectorDialog.js
+++ b/src/pages/tables/edit-table-template/EditTableCell/DataSelectorDialog/DataSelectorDialog.js
@@ -11,10 +11,7 @@ import {
 import { debounce } from 'lodash'
 import i18n from '../../../../../locales'
 
-import DataTypes from './DataTypesSelector'
-import Groups from './Groups'
-import FilterField from './FilterField'
-import DimensionItemsMenu from './DimensionItemsMenu'
+import { DataTypes, Groups, FilterField, DimensionItemsMenu } from './index'
 import { modal, modalContent } from './styles/DataSelectorDialog.module.css'
 
 import {

--- a/src/pages/tables/edit-table-template/EditTableCell/DataSelectorDialog/index.js
+++ b/src/pages/tables/edit-table-template/EditTableCell/DataSelectorDialog/index.js
@@ -1,1 +1,5 @@
 export * from './DataSelectorDialog'
+export * from './DimensionItemsMenu'
+export * from './DataTypesSelector'
+export * from './FilterField'
+export * from './Groups'


### PR DESCRIPTION
Related to #9 - No longer populates filter text in Data Selector Dialog when editing a data item, which makes for a clearer UX.