### PR TITLE
feat: add buttons to template actions

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2020-12-12T00:13:28.882Z\n"
-"PO-Revision-Date: 2020-12-12T00:13:28.882Z\n"
+"POT-Creation-Date: 2020-12-12T07:31:15.327Z\n"
+"PO-Revision-Date: 2020-12-12T07:31:15.327Z\n"
 
 msgid "Back"
 msgstr ""
@@ -144,16 +144,16 @@ msgstr ""
 msgid "One or more periods are required to query data for this table."
 msgstr ""
 
-msgid "Generate Report"
+msgid "Report"
 msgstr ""
 
 msgid "Tip - hover the mouse over a data cell to see its information."
 msgstr ""
 
-msgid "Choose Parameters"
+msgid "Change Report Parameters"
 msgstr ""
 
-msgid "Edit Template"
+msgid "View Template"
 msgstr ""
 
 msgid "Print"
@@ -262,6 +262,9 @@ msgid "Enter text"
 msgstr ""
 
 msgid "Enter static text for cell"
+msgstr ""
+
+msgid "Generate Report"
 msgstr ""
 
 msgid "Really delete this template?"

--- a/src/pages/tables/saved-table-templates/SavedTableTemplateActions.js
+++ b/src/pages/tables/saved-table-templates/SavedTableTemplateActions.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { FlyoutMenu, MenuItem } from '@dhis2/ui'
+import { Button, FlyoutMenu } from '@dhis2/ui'
 import i18n from '../../../locales'
 
 import Icon from '../../../components/Icon'
@@ -9,34 +9,36 @@ import PopoverButton from '../../../components/PopoverButton'
 
 export function SavedTableTemplateActions({ onGenerate, onEdit, onDelete }) {
     return (
-        <PopoverButton tooltip={i18n.t('Table actions')}>
-            {togglePopover => (
-                <FlyoutMenu>
-                    <MenuItem
-                        icon={<Icon name="play_arrow" />}
-                        label={i18n.t('Generate Table')}
-                        onClick={() => {
-                            onGenerate()
-                            togglePopover()
-                        }}
-                    />
-                    <MenuItem
-                        icon={<Icon name="edit" />}
-                        label={i18n.t('View & Edit')}
-                        onClick={() => {
-                            onEdit()
-                            togglePopover()
-                        }}
-                    />
-                    <DeleteTableTemplate
-                        onDeleteConfirmation={() => {
-                            onDelete()
-                            togglePopover()
-                        }}
-                    />
-                </FlyoutMenu>
-            )}
-        </PopoverButton>
+        <div>
+            <Button
+                icon={<Icon name="play_arrow" size="18px" />}
+                onClick={onGenerate}
+            >
+                {i18n.t('Generate')}
+            </Button>
+            <Button icon={<Icon name="edit" size="18px" />} onClick={onEdit}>
+                {i18n.t('Edit')}
+            </Button>
+            <PopoverButton tooltip={i18n.t('Table actions')}>
+                {togglePopover => (
+                    <FlyoutMenu>
+                        <DeleteTableTemplate
+                            onDeleteConfirmation={() => {
+                                onDelete()
+                                togglePopover()
+                            }}
+                        />
+                    </FlyoutMenu>
+                )}
+            </PopoverButton>
+            <style jsx>{`
+                div {
+                    display: flex;
+                    align-items: center;
+                    gap: 1rem;
+                }
+            `}</style>
+        </div>
     )
 }
 

--- a/src/pages/tables/saved-table-templates/SavedTableTemplateActions.js
+++ b/src/pages/tables/saved-table-templates/SavedTableTemplateActions.js
@@ -4,7 +4,7 @@ import { FlyoutMenu, MenuItem } from '@dhis2/ui'
 import i18n from '../../../locales'
 
 import Icon from '../../../components/Icon'
-import DeleteTableTemplate from './DeleteTableTemplate'
+import { DeleteTableTemplate } from './DeleteTableTemplate'
 import PopoverButton from '../../../components/PopoverButton'
 
 export function SavedTableTemplateActions({ onGenerate, onEdit, onDelete }) {


### PR DESCRIPTION
Move 'Edit' and 'Generate' actions from popover menu to buttons on rows of saved templates - Relates to #9 